### PR TITLE
[SAT-11] Create landing page header component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.cursorBlinking": "solid"
+}

--- a/public/adventure-illustration.svg
+++ b/public/adventure-illustration.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="800" height="600" fill="#f0f9ff"/>
+  
+  <!-- Mountain Range -->
+  <path d="M0 400 L200 200 L400 350 L600 150 L800 300 L800 600 L0 600 Z" fill="#94a3b8"/>
+  
+  <!-- Sun -->
+  <circle cx="650" cy="100" r="60" fill="#fbbf24"/>
+  
+  <!-- Path -->
+  <path d="M100 500 Q400 300 700 500" stroke="#4b5563" stroke-width="8" fill="none"/>
+  
+  <!-- Trees -->
+  <path d="M150 450 L150 350 L200 400 L150 450" fill="#166534"/>
+  <path d="M300 500 L300 400 L350 450 L300 500" fill="#166534"/>
+  <path d="M500 450 L500 350 L550 400 L500 450" fill="#166534"/>
+  
+  <!-- Adventure Character -->
+  <circle cx="400" cy="450" r="20" fill="#1e40af"/>
+  <path d="M400 470 L400 500" stroke="#1e40af" stroke-width="4"/>
+  <path d="M400 500 L380 530" stroke="#1e40af" stroke-width="4"/>
+  <path d="M400 500 L420 530" stroke="#1e40af" stroke-width="4"/>
+</svg> 

--- a/src/app/components/LandingHeader.tsx
+++ b/src/app/components/LandingHeader.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function LandingHeader() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="flex flex-col md:flex-row items-center justify-between gap-8">
+        {/* Left section - Header content */}
+        <div className="flex-1 text-center md:text-left">
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">
+            Cheep your own Adventure
+          </h1>
+          <p className="text-lg md:text-xl mb-8 text-gray-600 dark:text-gray-300">
+            Create your own stories, step by step. Or follow another's rabbit hole.
+          </p>
+          <div className="flex flex-row gap-4 justify-center md:justify-start">
+            <Link 
+              href="/read"
+              className="px-6 py-3 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+            >
+              Read
+            </Link>
+            <Link 
+              href="/write"
+              className="px-6 py-3 rounded-lg border-2 border-blue-600 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+            >
+              Write
+            </Link>
+          </div>
+        </div>
+
+        {/* Right section - Image */}
+        <div className="flex-1 relative w-full h-[300px] md:h-[400px]">
+          <Image
+            src="/adventure-illustration.svg"
+            alt="Adventure illustration"
+            fill
+            className="object-contain"
+            priority
+          />
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import LandingHeader from './components/LandingHeader';
 
 export const metadata: Metadata = {
   title: 'CheepAdventure',
@@ -6,8 +7,8 @@ export const metadata: Metadata = {
 
 export default function Home() {
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <h1 className="text-4xl font-bold">CheepAdventure coming soon</h1>
-    </div>
+    <main>
+      <LandingHeader />
+    </main>
   );
 }


### PR DESCRIPTION
This component will be the header on the root landing page ([https://github.com/jgmcalpine/CheepAdventure/blob/main/src/app/page.tsx](https://github.com/jgmcalpine/CheepAdventure/blob/main/src/app/page.tsx)).

The header should be mobile-first responsive design.

On mobile, there should be a section on the top with a main header and a subheader. The header text should be: "Cheep your own Adventure". The subheader should be: "Create your own stories, step by step. Or follow another's rabbit hole." Below this, there should be two buttons on the same line, one that says "Read" and the other "Write". These buttons should navigate to the /read and /write routes, respectively. One button should be the primary color scheme, the other should be secondary. Below this there should be an image. 

On desktop, the section with the header, subheader, and buttons should be on the left side. The image should be on the right.

Linked ticket: SAT-11